### PR TITLE
fix: getObjectWithKey type

### DIFF
--- a/packages/zep-script/src/ScriptMap.d.ts
+++ b/packages/zep-script/src/ScriptMap.d.ts
@@ -446,7 +446,7 @@ declare global {
      */
     function getObjectWithKey(
       key: string,
-    ): MapDataTileAppObject;
+    ): NpcObject;
 
     /**
      * 해당하는 레이어의 x, y 좌표에 있는 타일의 타입 값을 리턴, 타일이 없으면 -1을 리턴합니다.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced function signatures for better type safety in the API.
	- Updated return type for `getObjectWithKey` to provide more specific object types.
	- Introduced overloads for `putObjectWithKey` to clarify expected parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->